### PR TITLE
Update deps and add Import assertions for Node 18 compat

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "@rollup/pluginutils": "^4.2.1",
         "acorn": "^8.8.0",
+        "acorn-import-assertions": "^1.8.0",
         "convert-source-map": "^1.8.0",
         "escodegen": "^2.0.0",
         "multi-stage-sourcemap": "^0.3.1",
@@ -89,6 +90,14 @@
       },
       "engines": {
         "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-import-assertions": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/acorn-import-assertions/-/acorn-import-assertions-1.8.0.tgz",
+      "integrity": "sha512-m7VZ3jwz4eK6A4Vtt8Ew1/mNbP24u0FhdyfA7fSvnJR6LMdfOYnmuIrrJAgrYfYJ10F/otaHTtrtrtmHdMNzEw==",
+      "peerDependencies": {
+        "acorn": "^8"
       }
     },
     "node_modules/acorn-jsx": {
@@ -2077,6 +2086,12 @@
       "version": "8.8.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.0.tgz",
       "integrity": "sha512-QOxyigPVrpZ2GXT+PFyZTl6TtOFc5egxHIP9IlQ+RbupQuX4RkT/Bee4/kQuC02Xkzg84JcT7oLYtDIQxp+v7w=="
+    },
+    "acorn-import-assertions": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/acorn-import-assertions/-/acorn-import-assertions-1.8.0.tgz",
+      "integrity": "sha512-m7VZ3jwz4eK6A4Vtt8Ew1/mNbP24u0FhdyfA7fSvnJR6LMdfOYnmuIrrJAgrYfYJ10F/otaHTtrtrtmHdMNzEw==",
+      "requires": {}
     },
     "acorn-jsx": {
       "version": "5.3.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,33 +10,33 @@
       "license": "Beerware",
       "dependencies": {
         "@rollup/pluginutils": "^4.2.1",
-        "acorn": "^8.7.1",
+        "acorn": "^8.8.0",
         "convert-source-map": "^1.8.0",
         "escodegen": "^2.0.0",
         "multi-stage-sourcemap": "^0.3.1",
         "unassert": "^1.6.0"
       },
       "devDependencies": {
-        "eslint": "^8.14.0",
+        "eslint": "^8.20.0",
         "eslint-config-mourner": "^3.0.0",
-        "rollup": "^2.70.2",
+        "rollup": "^2.77.2",
         "tape": "^5.5.3"
       }
     },
     "node_modules/@eslint/eslintrc": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.2.2.tgz",
-      "integrity": "sha512-lTVWHs7O2hjBFZunXTZYnYqtB9GakA1lnxIf+gKq2nY5gxkkNi/lQvveW6t8gFdOHTg6nG50Xs95PrLqVpcaLg==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.3.0.tgz",
+      "integrity": "sha512-UWW0TMTmk2d7hLcWD1/e2g5HDM/HQ3csaLSqXCfqwh4uNDuNqlaKWXmEsL4Cs41Z0KnILNvwbHAah3C2yt06kw==",
       "dev": true,
       "dependencies": {
         "ajv": "^6.12.4",
         "debug": "^4.3.2",
-        "espree": "^9.3.1",
-        "globals": "^13.9.0",
+        "espree": "^9.3.2",
+        "globals": "^13.15.0",
         "ignore": "^5.2.0",
         "import-fresh": "^3.2.1",
         "js-yaml": "^4.1.0",
-        "minimatch": "^3.0.4",
+        "minimatch": "^3.1.2",
         "strip-json-comments": "^3.1.1"
       },
       "engines": {
@@ -81,9 +81,9 @@
       "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w=="
     },
     "node_modules/acorn": {
-      "version": "8.7.1",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.7.1.tgz",
-      "integrity": "sha512-Xx54uLJQZ19lKygFXOWsscKUbsBZW0CPykPhVQdhIeIwrbPmJzqeASDInc8nKBnp/JT6igTs82qPXz069H8I/A==",
+      "version": "8.8.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.0.tgz",
+      "integrity": "sha512-QOxyigPVrpZ2GXT+PFyZTl6TtOFc5egxHIP9IlQ+RbupQuX4RkT/Bee4/kQuC02Xkzg84JcT7oLYtDIQxp+v7w==",
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -514,12 +514,12 @@
       }
     },
     "node_modules/eslint": {
-      "version": "8.14.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.14.0.tgz",
-      "integrity": "sha512-3/CE4aJX7LNEiE3i6FeodHmI/38GZtWCsAtsymScmzYapx8q1nVVb+eLcLSzATmCPXw5pT4TqVs1E0OmxAd9tw==",
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.20.0.tgz",
+      "integrity": "sha512-d4ixhz5SKCa1D6SCPrivP7yYVi7nyD6A4vs6HIAul9ujBzcEmZVM3/0NN/yu5nKhmO1wjp5xQ46iRfmDGlOviA==",
       "dev": true,
       "dependencies": {
-        "@eslint/eslintrc": "^1.2.2",
+        "@eslint/eslintrc": "^1.3.0",
         "@humanwhocodes/config-array": "^0.9.2",
         "ajv": "^6.10.0",
         "chalk": "^4.0.0",
@@ -530,14 +530,14 @@
         "eslint-scope": "^7.1.1",
         "eslint-utils": "^3.0.0",
         "eslint-visitor-keys": "^3.3.0",
-        "espree": "^9.3.1",
+        "espree": "^9.3.2",
         "esquery": "^1.4.0",
         "esutils": "^2.0.2",
         "fast-deep-equal": "^3.1.3",
         "file-entry-cache": "^6.0.1",
         "functional-red-black-tree": "^1.0.1",
         "glob-parent": "^6.0.1",
-        "globals": "^13.6.0",
+        "globals": "^13.15.0",
         "ignore": "^5.2.0",
         "import-fresh": "^3.0.0",
         "imurmurhash": "^0.1.4",
@@ -546,7 +546,7 @@
         "json-stable-stringify-without-jsonify": "^1.0.1",
         "levn": "^0.4.1",
         "lodash.merge": "^4.6.2",
-        "minimatch": "^3.0.4",
+        "minimatch": "^3.1.2",
         "natural-compare": "^1.4.0",
         "optionator": "^0.9.1",
         "regexpp": "^3.2.0",
@@ -638,13 +638,13 @@
       }
     },
     "node_modules/espree": {
-      "version": "9.3.1",
-      "resolved": "https://registry.npmjs.org/espree/-/espree-9.3.1.tgz",
-      "integrity": "sha512-bvdyLmJMfwkV3NCRl5ZhJf22zBFo1y8bYh3VYb+bfzqNB4Je68P2sSuXyuFquzWLebHpNd2/d5uv7yoP9ISnGQ==",
+      "version": "9.3.2",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-9.3.2.tgz",
+      "integrity": "sha512-D211tC7ZwouTIuY5x9XnS0E9sWNChB7IYKX/Xp5eQj3nFXhqmiUDB9q27y76oFl8jTg3pXcQx/bpxMfs3CIZbA==",
       "dev": true,
       "dependencies": {
-        "acorn": "^8.7.0",
-        "acorn-jsx": "^5.3.1",
+        "acorn": "^8.7.1",
+        "acorn-jsx": "^5.3.2",
         "eslint-visitor-keys": "^3.3.0"
       },
       "engines": {
@@ -881,9 +881,9 @@
       }
     },
     "node_modules/globals": {
-      "version": "13.13.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-13.13.0.tgz",
-      "integrity": "sha512-EQ7Q18AJlPwp3vUDL4mKA0KXrXyNIQyWon6T6XQiBQF0XHvRsiCSrWmmeATpUzdJN2HhWZU6Pdl0a9zdep5p6A==",
+      "version": "13.17.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-13.17.0.tgz",
+      "integrity": "sha512-1C+6nQRb1GwGMKm2dH/E7enFAMxGTmGI7/dEdhy/DNelv85w9B72t3uc5frtMNXIbzrarJJ/lTCjcaZwbLJmyw==",
       "dev": true,
       "dependencies": {
         "type-fest": "^0.20.2"
@@ -1652,9 +1652,9 @@
       }
     },
     "node_modules/rollup": {
-      "version": "2.70.2",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.70.2.tgz",
-      "integrity": "sha512-EitogNZnfku65I1DD5Mxe8JYRUCy0hkK5X84IlDtUs+O6JRMpRciXTzyCUuX11b5L5pvjH+OmFXiQ3XjabcXgg==",
+      "version": "2.77.2",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.77.2.tgz",
+      "integrity": "sha512-m/4YzYgLcpMQbxX3NmAqDvwLATZzxt8bIegO78FZLl+lAgKJBd1DRAOeEiZcKOIOPjxE6ewHWHNgGEalFXuz1g==",
       "dev": true,
       "bin": {
         "rollup": "dist/bin/rollup"
@@ -2024,19 +2024,19 @@
   },
   "dependencies": {
     "@eslint/eslintrc": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.2.2.tgz",
-      "integrity": "sha512-lTVWHs7O2hjBFZunXTZYnYqtB9GakA1lnxIf+gKq2nY5gxkkNi/lQvveW6t8gFdOHTg6nG50Xs95PrLqVpcaLg==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.3.0.tgz",
+      "integrity": "sha512-UWW0TMTmk2d7hLcWD1/e2g5HDM/HQ3csaLSqXCfqwh4uNDuNqlaKWXmEsL4Cs41Z0KnILNvwbHAah3C2yt06kw==",
       "dev": true,
       "requires": {
         "ajv": "^6.12.4",
         "debug": "^4.3.2",
-        "espree": "^9.3.1",
-        "globals": "^13.9.0",
+        "espree": "^9.3.2",
+        "globals": "^13.15.0",
         "ignore": "^5.2.0",
         "import-fresh": "^3.2.1",
         "js-yaml": "^4.1.0",
-        "minimatch": "^3.0.4",
+        "minimatch": "^3.1.2",
         "strip-json-comments": "^3.1.1"
       }
     },
@@ -2074,9 +2074,9 @@
       }
     },
     "acorn": {
-      "version": "8.7.1",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.7.1.tgz",
-      "integrity": "sha512-Xx54uLJQZ19lKygFXOWsscKUbsBZW0CPykPhVQdhIeIwrbPmJzqeASDInc8nKBnp/JT6igTs82qPXz069H8I/A=="
+      "version": "8.8.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.0.tgz",
+      "integrity": "sha512-QOxyigPVrpZ2GXT+PFyZTl6TtOFc5egxHIP9IlQ+RbupQuX4RkT/Bee4/kQuC02Xkzg84JcT7oLYtDIQxp+v7w=="
     },
     "acorn-jsx": {
       "version": "5.3.2",
@@ -2396,12 +2396,12 @@
       }
     },
     "eslint": {
-      "version": "8.14.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.14.0.tgz",
-      "integrity": "sha512-3/CE4aJX7LNEiE3i6FeodHmI/38GZtWCsAtsymScmzYapx8q1nVVb+eLcLSzATmCPXw5pT4TqVs1E0OmxAd9tw==",
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.20.0.tgz",
+      "integrity": "sha512-d4ixhz5SKCa1D6SCPrivP7yYVi7nyD6A4vs6HIAul9ujBzcEmZVM3/0NN/yu5nKhmO1wjp5xQ46iRfmDGlOviA==",
       "dev": true,
       "requires": {
-        "@eslint/eslintrc": "^1.2.2",
+        "@eslint/eslintrc": "^1.3.0",
         "@humanwhocodes/config-array": "^0.9.2",
         "ajv": "^6.10.0",
         "chalk": "^4.0.0",
@@ -2412,14 +2412,14 @@
         "eslint-scope": "^7.1.1",
         "eslint-utils": "^3.0.0",
         "eslint-visitor-keys": "^3.3.0",
-        "espree": "^9.3.1",
+        "espree": "^9.3.2",
         "esquery": "^1.4.0",
         "esutils": "^2.0.2",
         "fast-deep-equal": "^3.1.3",
         "file-entry-cache": "^6.0.1",
         "functional-red-black-tree": "^1.0.1",
         "glob-parent": "^6.0.1",
-        "globals": "^13.6.0",
+        "globals": "^13.15.0",
         "ignore": "^5.2.0",
         "import-fresh": "^3.0.0",
         "imurmurhash": "^0.1.4",
@@ -2428,7 +2428,7 @@
         "json-stable-stringify-without-jsonify": "^1.0.1",
         "levn": "^0.4.1",
         "lodash.merge": "^4.6.2",
-        "minimatch": "^3.0.4",
+        "minimatch": "^3.1.2",
         "natural-compare": "^1.4.0",
         "optionator": "^0.9.1",
         "regexpp": "^3.2.0",
@@ -2494,13 +2494,13 @@
       "dev": true
     },
     "espree": {
-      "version": "9.3.1",
-      "resolved": "https://registry.npmjs.org/espree/-/espree-9.3.1.tgz",
-      "integrity": "sha512-bvdyLmJMfwkV3NCRl5ZhJf22zBFo1y8bYh3VYb+bfzqNB4Je68P2sSuXyuFquzWLebHpNd2/d5uv7yoP9ISnGQ==",
+      "version": "9.3.2",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-9.3.2.tgz",
+      "integrity": "sha512-D211tC7ZwouTIuY5x9XnS0E9sWNChB7IYKX/Xp5eQj3nFXhqmiUDB9q27y76oFl8jTg3pXcQx/bpxMfs3CIZbA==",
       "dev": true,
       "requires": {
-        "acorn": "^8.7.0",
-        "acorn-jsx": "^5.3.1",
+        "acorn": "^8.7.1",
+        "acorn-jsx": "^5.3.2",
         "eslint-visitor-keys": "^3.3.0"
       }
     },
@@ -2678,9 +2678,9 @@
       }
     },
     "globals": {
-      "version": "13.13.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-13.13.0.tgz",
-      "integrity": "sha512-EQ7Q18AJlPwp3vUDL4mKA0KXrXyNIQyWon6T6XQiBQF0XHvRsiCSrWmmeATpUzdJN2HhWZU6Pdl0a9zdep5p6A==",
+      "version": "13.17.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-13.17.0.tgz",
+      "integrity": "sha512-1C+6nQRb1GwGMKm2dH/E7enFAMxGTmGI7/dEdhy/DNelv85w9B72t3uc5frtMNXIbzrarJJ/lTCjcaZwbLJmyw==",
       "dev": true,
       "requires": {
         "type-fest": "^0.20.2"
@@ -3225,9 +3225,9 @@
       }
     },
     "rollup": {
-      "version": "2.70.2",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.70.2.tgz",
-      "integrity": "sha512-EitogNZnfku65I1DD5Mxe8JYRUCy0hkK5X84IlDtUs+O6JRMpRciXTzyCUuX11b5L5pvjH+OmFXiQ3XjabcXgg==",
+      "version": "2.77.2",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.77.2.tgz",
+      "integrity": "sha512-m/4YzYgLcpMQbxX3NmAqDvwLATZzxt8bIegO78FZLl+lAgKJBd1DRAOeEiZcKOIOPjxE6ewHWHNgGEalFXuz1g==",
       "dev": true,
       "requires": {
         "fsevents": "~2.3.2"

--- a/package.json
+++ b/package.json
@@ -10,16 +10,16 @@
   ],
   "dependencies": {
     "@rollup/pluginutils": "^4.2.1",
-    "acorn": "^8.7.1",
+    "acorn": "^8.8.0",
     "convert-source-map": "^1.8.0",
     "escodegen": "^2.0.0",
     "multi-stage-sourcemap": "^0.3.1",
     "unassert": "^1.6.0"
   },
   "devDependencies": {
-    "eslint": "^8.14.0",
+    "eslint": "^8.20.0",
     "eslint-config-mourner": "^3.0.0",
-    "rollup": "^2.70.2",
+    "rollup": "^2.77.2",
     "tape": "^5.5.3"
   },
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   "dependencies": {
     "@rollup/pluginutils": "^4.2.1",
     "acorn": "^8.8.0",
+    "acorn-import-assertions": "^1.8.0",
     "convert-source-map": "^1.8.0",
     "escodegen": "^2.0.0",
     "multi-stage-sourcemap": "^0.3.1",

--- a/src/unassert.js
+++ b/src/unassert.js
@@ -1,6 +1,7 @@
 
 import {createFilter} from '@rollup/pluginutils';
-import acorn from 'acorn';
+import {Parser} from 'acorn';
+import {importAssertions} from 'acorn-import-assertions';
 import escodegen from 'escodegen';
 import unassertjs from 'unassert';
 import convert from 'convert-source-map';
@@ -61,7 +62,7 @@ export default function unassert(options = {}) {
                 const comments = [];
                 const tokens = [];
 
-                const ast = acorn.parse(code, {
+                const ast = Parser.extend(importAssertions).parse(code, {
                     sourceType: 'module',
                     ecmaVersion: 'latest',
                     locations: true,


### PR DESCRIPTION
This is to provide compatibility with node 18 and ts-node  > v10.8.1.

Without this an error would occur for lines like:

`import spec from './v8.json' assert { type: 'json' };`