### PR TITLE
Switch to `@javascript-obfuscator/escodegen`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,10 +9,10 @@
       "version": "0.5.0",
       "license": "Beerware",
       "dependencies": {
+        "@javascript-obfuscator/escodegen": "^2.3.0",
         "@rollup/pluginutils": "^4.2.1",
         "acorn": "^8.8.0",
         "convert-source-map": "^1.8.0",
-        "escodegen": "^2.0.0",
         "multi-stage-sourcemap": "^0.3.1",
         "unassert": "^2.0.0"
       },
@@ -72,6 +72,31 @@
       "resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-1.2.1.tgz",
       "integrity": "sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==",
       "dev": true
+    },
+    "node_modules/@javascript-obfuscator/escodegen": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@javascript-obfuscator/escodegen/-/escodegen-2.3.0.tgz",
+      "integrity": "sha512-QVXwMIKqYMl3KwtTirYIA6gOCiJ0ZDtptXqAv/8KWLG9uQU2fZqTVy7a/A5RvcoZhbDoFfveTxuGxJ5ibzQtkw==",
+      "dependencies": {
+        "@javascript-obfuscator/estraverse": "^5.3.0",
+        "esprima": "^4.0.1",
+        "esutils": "^2.0.2",
+        "optionator": "^0.8.1"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "optionalDependencies": {
+        "source-map": "~0.6.1"
+      }
+    },
+    "node_modules/@javascript-obfuscator/estraverse": {
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/@javascript-obfuscator/estraverse/-/estraverse-5.4.0.tgz",
+      "integrity": "sha512-CZFX7UZVN9VopGbjTx4UXaXsi9ewoM1buL0kY7j1ftYdSs7p2spv9opxFjHlQ/QGTgh4UqufYqJJ0WKLml7b6w==",
+      "engines": {
+        "node": ">=4.0"
+      }
     },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
@@ -534,27 +559,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/escodegen": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-2.0.0.tgz",
-      "integrity": "sha512-mmHKys/C8BFUGI+MAWNcSYoORYLMdPzjrknd2Vc+bUsjN5bXcr8EhrNB+UTqfL1y3I9c4fw2ihgtMPQLBRiQxw==",
-      "dependencies": {
-        "esprima": "^4.0.1",
-        "estraverse": "^5.2.0",
-        "esutils": "^2.0.2",
-        "optionator": "^0.8.1"
-      },
-      "bin": {
-        "escodegen": "bin/escodegen.js",
-        "esgenerate": "bin/esgenerate.js"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "optionalDependencies": {
-        "source-map": "~0.6.1"
       }
     },
     "node_modules/eslint": {
@@ -2379,6 +2383,23 @@
       "integrity": "sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==",
       "dev": true
     },
+    "@javascript-obfuscator/escodegen": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@javascript-obfuscator/escodegen/-/escodegen-2.3.0.tgz",
+      "integrity": "sha512-QVXwMIKqYMl3KwtTirYIA6gOCiJ0ZDtptXqAv/8KWLG9uQU2fZqTVy7a/A5RvcoZhbDoFfveTxuGxJ5ibzQtkw==",
+      "requires": {
+        "@javascript-obfuscator/estraverse": "^5.3.0",
+        "esprima": "^4.0.1",
+        "esutils": "^2.0.2",
+        "optionator": "^0.8.1",
+        "source-map": "~0.6.1"
+      }
+    },
+    "@javascript-obfuscator/estraverse": {
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/@javascript-obfuscator/estraverse/-/estraverse-5.4.0.tgz",
+      "integrity": "sha512-CZFX7UZVN9VopGbjTx4UXaXsi9ewoM1buL0kY7j1ftYdSs7p2spv9opxFjHlQ/QGTgh4UqufYqJJ0WKLml7b6w=="
+    },
     "@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -2722,18 +2743,6 @@
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
       "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
       "dev": true
-    },
-    "escodegen": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-2.0.0.tgz",
-      "integrity": "sha512-mmHKys/C8BFUGI+MAWNcSYoORYLMdPzjrknd2Vc+bUsjN5bXcr8EhrNB+UTqfL1y3I9c4fw2ihgtMPQLBRiQxw==",
-      "requires": {
-        "esprima": "^4.0.1",
-        "estraverse": "^5.2.0",
-        "esutils": "^2.0.2",
-        "optionator": "^0.8.1",
-        "source-map": "~0.6.1"
-      }
     },
     "eslint": {
       "version": "8.21.0",

--- a/package.json
+++ b/package.json
@@ -9,10 +9,10 @@
     "dist"
   ],
   "dependencies": {
+    "@javascript-obfuscator/escodegen": "^2.3.0",
     "@rollup/pluginutils": "^4.2.1",
     "acorn": "^8.8.0",
     "convert-source-map": "^1.8.0",
-    "escodegen": "^2.0.0",
     "multi-stage-sourcemap": "^0.3.1",
     "unassert": "^2.0.0"
   },

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,7 +1,7 @@
 
 const config = format => ({
     input: 'src/unassert.js',
-    external: ['rollup-pluginutils', 'acorn', 'escodegen', 'unassert', 'convert-source-map', 'multi-stage-sourcemap'],
+    external: ['rollup-pluginutils', 'acorn', '@javascript-obfuscator/escodegen', 'unassert', 'convert-source-map', 'multi-stage-sourcemap'],
     output: {
         file: `dist/rollup-plugin-unassert.${format}.js`,
         format

--- a/src/unassert.js
+++ b/src/unassert.js
@@ -1,7 +1,7 @@
 
 import {createFilter} from '@rollup/pluginutils';
 import acorn from 'acorn';
-import escodegen from 'escodegen';
+import escodegen from '@javascript-obfuscator/escodegen';
 import {unassertAst} from 'unassert';
 import convert from 'convert-source-map';
 import {transfer} from 'multi-stage-sourcemap';


### PR DESCRIPTION
The last `escodegen` release was back in 2020 and seems no longer maintained. The last version lacks some important features support, such as https://github.com/estools/escodegen/issues/443

A community fork, `@javascript-obfuscator/escodegen`, implements this.